### PR TITLE
[chore] groupId url에 연동

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import ShowGroupDetails from './Pages/ShowGroupDetails'
 import NavBar from './Components/NavBar/NavBar'
 import MainPage from './Pages/MainPage'
 import SideBar from './Components/SideBar/SideBar'
+import GroupMainPage from './Pages/GroupMainPage'
 
 const StyledLayout = styled.div`
     // background-color: gray;
@@ -32,6 +33,7 @@ function App() {
                         <Route path="/group" element={<ShowGroupList />} />
                         <Route path="/group/:id/ShowGroupDetails" element={<ShowGroupDetails />} />
                         <Route path="/group/:id/createEvent" element={<CreateEventPage />} />
+                        <Route path="/group/:id" element={<GroupMainPage />} />
                     </Routes>
                 </StyledLayout>
             </div>

--- a/src/Components/GroupCard/GroupCard.js
+++ b/src/Components/GroupCard/GroupCard.js
@@ -5,7 +5,7 @@ import { Card, Col, Row } from 'antd'
 import { Link } from 'react-router-dom'
 import { getGroups } from '../../apis/groups'
 import styled from 'styled-components'
-
+import SideBar from '../SideBar/SideBar'
 const StyledBox = styled.div`
     display: flex;
     width: 100%;
@@ -46,7 +46,8 @@ const GroupCard = () => {
             <StyledRow gutter={16}>
                 <StyledCol span={8}>
                     {groups.map((group) => (
-                        <Link to={`/group/${group._id}/member`} key={group._id}>
+                        <Link to={`/group/${group._id}`} key={group._id}>
+                            <SideBar group_id={group._id} />
                             <StyledCard title={group.name} bordered={false}>
                                 {group.description}
                             </StyledCard>

--- a/src/Components/SideBar/SideBar.js
+++ b/src/Components/SideBar/SideBar.js
@@ -85,34 +85,30 @@ const SideBar = ({ group_id }) => {
         {
             index: 1,
             name: '거래내역 업로드',
-            path: '/uploadfile',
+            path: `group/${group_id}/uploadResult`,
         },
         {
             index: 2,
             name: '이벤트별 조회',
-            path: '/eventcount',
+            path: `group/${group_id}/showResult`,
         },
         {
             index: 3,
             name: '거래내역분석',
-            path: '/result',
+            path: `group/${group_id}/showResult`,
         },
     ]
 
-    //const [groupIdSet, setGroupIdSet] = useState([])
-    // const [refresh, setRefresh] = useState(1)
     const [members, setMembers] = useState([])
     const groupId = window.location.href.split('/')[4]
     useEffect(() => {
         getMember(groupId).then((data) => {
             setMembers(data)
         })
-    }, [groupId])
+    }, [])
     console.log(members)
-    //console.log(groupIdSet)
-    console.log(group_id)
-    if (window.location.pathname === '/group') return null
-    if (window.location.pathname === '/createGroup') return null
+
+    if (window.location.pathname === '/group' || window.location.pathname === '/') return null
     return (
         <StyledSideBarBox>
             <ul>

--- a/src/Pages/GroupMainPage/index.js
+++ b/src/Pages/GroupMainPage/index.js
@@ -1,0 +1,8 @@
+import React from 'react'
+// import styled from 'styled-components'
+
+const GroupMainPage = () => {
+    return <div>그룹 메인 페이지 (새로고침 한 번만 해주세요 ... )</div>
+}
+
+export default GroupMainPage

--- a/src/Pages/MainPage/index.js
+++ b/src/Pages/MainPage/index.js
@@ -2,91 +2,21 @@ import React, { useEffect, useState } from 'react' // eslint-disable-line no-unu
 import { useNavigate } from 'react-router-dom' // eslint-disable-line no-unused-vars
 import styled from 'styled-components' // eslint-disable-line no-unused-vars
 import { getMember } from '../../apis/members' // eslint-disable-line no-unused-vars
+
 const MainPage = () => {
-    return <div>MainPage</div>
+    const navigate = useNavigate()
+    const onClickHandler = () => {
+        navigate('/group')
+    }
+
+    return (
+        <div>
+            환영합니다... 로그인하기...<br></br>
+            <button type="button" onClick={onClickHandler}>
+                일단 로그인없이 테스트
+            </button>
+        </div>
+    )
 }
-
-// const StyledMenu = styled.div`
-//     float: left;
-//     margin: 20px;
-// `
-
-// const StyledTitle = styled.div`
-//     padding: 30px 0 10px 0;
-//     // cursor: pointer;
-// `
-// const StyledSubTitle = styled.div`
-//     padding: 6px 15px;
-//     cursor: pointer;
-//     border-left: 2px solid #fff;
-
-//     &:hover {
-//         background-color: rgb(0, 63, 150, 0.1);
-//         //border-radius: 5px;
-//         border-left: 2px solid rgb(0, 63, 150);
-//     }
-// `
-
-// const MainPage = () => {
-//     const navigate = useNavigate()
-//     // const [members, setMembers] = useState([])
-//     // const groupId = window.location.href.split('/')[4]
-//     // useEffect(() => {
-//     //     getMember(groupId).then((data) => {
-//     //         setMembers(data)
-//     //     })
-//     // }, [groupId])
-
-//     // console.log(members)
-//     const onClickUploadMemberList = () => {
-//         navigate('/member')
-//     }
-
-//     const onClickMemberList = () => {
-//         navigate('/member')
-//         // /group/{groupId}/member
-//     }
-
-//     const onClickCreateEvent = () => {
-//         navigate('/member')
-//         // /group/{groupId}/event
-//     }
-//     const onClickEventList = () => {
-//         navigate('/member')
-//         // /group/{groupId}/event
-//     }
-//     const onClickEditGroup = () => {
-//         navigate('/member')
-//     }
-//     const onClickSubManager = () => {
-//         navigate('/member')
-//     }
-//     const onClickCheckEvent = () => {
-//         navigate('/member')
-//     }
-//     const onClickResult = () => {
-//         navigate('/member')
-//     }
-
-//     return (
-//         <div>
-//             <StyledMenu>
-//                 <StyledTitle>회원 관리</StyledTitle>
-//                 <StyledSubTitle onClick={onClickUploadMemberList}>회원 명단 업로드</StyledSubTitle>
-//                 <StyledSubTitle onClick={onClickMemberList}>회원 목록</StyledSubTitle>
-//                 <StyledTitle>이벤트</StyledTitle>
-//                 <StyledSubTitle onClick={onClickCreateEvent}>이벤트 생성</StyledSubTitle>
-//                 <StyledSubTitle onClick={onClickEventList}>이벤트 목록</StyledSubTitle>
-//                 <StyledTitle>설정</StyledTitle>
-//                 <StyledSubTitle onClick={onClickEditGroup}>모임 정보 변경</StyledSubTitle>
-//                 <StyledSubTitle onClick={onClickSubManager}>부매니저 설정</StyledSubTitle>
-//                 <StyledTitle>거래내역</StyledTitle>
-//                 <StyledSubTitle onClick={onClickResult}>거래내역 업로드</StyledSubTitle>
-//                 <StyledSubTitle onClick={onClickCheckEvent}>이벤트별 조회</StyledSubTitle>
-//                 <StyledSubTitle onClick={onClickResult}>거래내역 분석</StyledSubTitle>
-//             </StyledMenu>
-//         </div>
-//     )
-// }
 
 export default MainPage


### PR DESCRIPTION
## 업데이트 유형

- [ ] Hot Fix
- [ ] Release
- [ ] Develop
- [ ] Others

## 업데이트 개요

* Fix # (issue)
* Feature # (issue)  
  [여기에 PR 한줄 요약 작성, 대상 이슈번호 작성.]

## 업데이트 요약

group 목록에서 group 누르면 각 group의 id가 url로 넘어감.

## 해결한 문제

그룹별 데이터 보여줄 수 있음

## 미해결 문제

- memberId로 grouplist 불러오기
- group 목록에서 group 클릭 후 새로고침해야 sideBar 보이는 문제 ..
- 
## 테스트

- [ ] 유닛 테스트
- [ ] 빌드 테스트 (통합 테스트)
- [ ] 기타 유효성 테스트

## 수정 사항 진단

- [ ] 코드가 이 프로젝트의 스타일 지침을 따릅니다.
- [ ] 코드에 대한 자체 리뷰를 수행했습니다.
- [ ] 변경 내역에 대해 주석을 작성했습니다.
- [ ] 해당 PR에 대한 문서를 변경했습니다.
- [ ] 기능, 정책, 수정 사항, 이슈에 대한 테스트 코드를 추가했습니다.
- [ ] 변경 내용이 로컬 개발환경에서의 테스트를 통과했습니다.
- [ ] 모든 종속 변경 사항이 병합되어 다운스트림 모듈에 게시되었습니다.
